### PR TITLE
Support kramdown 2.0, slack embedded links

### DIFF
--- a/lib/kramdown/converter/slack.rb
+++ b/lib/kramdown/converter/slack.rb
@@ -70,6 +70,7 @@ module Kramdown
       end
 
       def convert_a(el)
+        return "<#{el.attr["href"]}|#{el.children.first.value}>" unless el.children.empty?
         el.attr["href"]
       end
       alias :convert_html_a :convert_a

--- a/lib/slackdown.rb
+++ b/lib/slackdown.rb
@@ -1,6 +1,7 @@
 require "slackdown/version"
 require "kramdown"
 require "kramdown/converter/slack"
+require "kramdown-parser-gfm"
 
 module Slackdown
 

--- a/slackdown.gemspec
+++ b/slackdown.gemspec
@@ -19,9 +19,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "kramdown", "~> 1.13.2"
+  spec.add_dependency "kramdown", "~> 2.0.0"
+  spec.add_dependency "kramdown-parser-gfm", "~> 1.0.1"
 
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "minitest-reporters"

--- a/test/slackdown_test.rb
+++ b/test/slackdown_test.rb
@@ -96,7 +96,7 @@ class SlackdownTest < Minitest::Test
   end
 
   should "replace links with their URL (Slack will unfurl them)" do
-    assert_converts "[Google](http://github.com)" => "http://github.com",
+    assert_converts "[Google](http://github.com)" => "<http://github.com|Google>",
                     '<a href="http://github.com" />' => "http://github.com"
   end
 


### PR DESCRIPTION
I've updated your library to support kramdown 2.0 and also added the ability to convert to links for slack formatting (see Linking to URLs on https://api.slack.com/docs/message-formatting)

Let me know if there's anything I can do to get this merged!