### PR TITLE
Support link text

### DIFF
--- a/lib/kramdown/converter/slack.rb
+++ b/lib/kramdown/converter/slack.rb
@@ -70,7 +70,9 @@ module Kramdown
       end
 
       def convert_a(el)
-        el.attr["href"]
+        content = inner(el)
+        return el.attr["href"] if content.nil? || content == ""
+        "<#{el.attr["href"]}|#{content}>"
       end
       alias :convert_html_a :convert_a
 

--- a/test/slackdown_test.rb
+++ b/test/slackdown_test.rb
@@ -96,7 +96,9 @@ class SlackdownTest < Minitest::Test
   end
 
   should "replace links with their URL (Slack will unfurl them)" do
-    assert_converts "[Google](http://github.com)" => "http://github.com",
+    assert_converts "[Google](http://github.com)" => "<http://github.com|Google>",
+                    "[](http://github.com)" => "http://github.com",
+                    "http://github.com" => "http://github.com",
                     '<a href="http://github.com" />' => "http://github.com"
   end
 


### PR DESCRIPTION
- Adds support for the link text using the `<link|title>` format from Slack

