### PR TITLE
Unlocked dependencies so that slackdown doesn't lock in a version of kramdown with a CVE (CVE-2020-14001)

### DIFF
--- a/lib/slackdown/version.rb
+++ b/lib/slackdown/version.rb
@@ -1,3 +1,3 @@
 module Slackdown
-  VERSION = "0.2.3"
+  VERSION = "0.2.4"
 end

--- a/slackdown.gemspec
+++ b/slackdown.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "kramdown", "~> 2.0.0"
-  spec.add_dependency "kramdown-parser-gfm", "~> 1.0.1"
+  spec.add_dependency "kramdown", "~> 2.3"
+  spec.add_dependency "kramdown-parser-gfm", "~> 1.0", ">= 1.0.1"
 
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "minitest-reporters"
   spec.add_development_dependency "minitest-reporters-turn_reporter"


### PR DESCRIPTION
Resolves #4 